### PR TITLE
Windows imports (#11)

### DIFF
--- a/.github/workflows/build-test-install.yml
+++ b/.github/workflows/build-test-install.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest,macos-latest,windows-latest]
-        sharedLib: [true,false]
+        sharedLib: [true]
         useThread: [true,false]
 
     uses: EddyTheCo/Common/.github/workflows/build-test-install.yml@main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ if (Qt6_FOUND)
 		${CMAKE_CURRENT_BINARY_DIR}/nodeConection
 		)
 
+	target_compile_definitions(nodeConection PRIVATE WINDOWS_NCONN)
 	target_link_libraries(nodeConection PUBLIC Qt6::Gui Qt6::Quick)
 
 
@@ -108,9 +109,9 @@ if (Qt6_FOUND)
 	if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
 		include(CTest)
 		set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-v${SEMVER}-${CMAKE_SYSTEM_NAME}_${CMAKE_SYSTEM_VERSION}-${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_CXX_COMPILER_ID}")
-		if(NOT BUILD_SHARED_LIBS)
-			set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-static")
-		endif(NOT BUILD_SHARED_LIBS)
+		if(USE_THREADS)
+			set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-MThread")
+		endif(USE_THREADS)
 		include(CPack)
 	endif()
 

--- a/include/nodeConnection.hpp
+++ b/include/nodeConnection.hpp
@@ -7,8 +7,14 @@
 #include"client/qclient.hpp"
 #include"client/qclientMQTT.hpp"
 
+#include <QtCore/QtGlobal>
+#if defined(WINDOWS_NCONN)
+# define NCONN_EXPORT Q_DECL_EXPORT
+#else
+#define NCONN_EXPORT Q_DECL_IMPORT
+#endif
 
-class Node_Conection: public QObject
+class NCONN_EXPORT Node_Conection: public QObject
 {
     Q_OBJECT
 


### PR DESCRIPTION
* fixed the export for windows static members

* package depending if multi threads, build shard static depending on qt build


* the exports definitions it is not need it on the member if the class already has it